### PR TITLE
Org rename (dev): LZeroAnalytics → 0xBloctopus (Kurtosis name)

### DIFF
--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,2 +1,2 @@
-name: "github.com/LZeroAnalytics/hyperlane-package"
+name: "github.com/0xBloctopus/hyperlane-package"
 description: Hyperlane offchain infra + HWR 2.0 with modular rebalancer


### PR DESCRIPTION
# Org rename (dev): LZeroAnalytics → 0xBloctopus (Kurtosis name)

## Summary
Updates the Kurtosis package name in `kurtosis.yml` from `github.com/LZeroAnalytics/hyperlane-package` to `github.com/0xBloctopus/hyperlane-package` as part of the organization-wide rename effort.

## Review & Testing Checklist for Human
- [ ] **Verify package name casing**: Confirm `0xBloctopus` (capital B) is the correct casing for the new organization name
- [ ] **Test package import**: Verify the package can still be imported using `kurtosis run github.com/0xBloctopus/hyperlane-package` 

### Notes
- This is a mechanical change as part of the broader GitHub organization rename from LZeroAnalytics to 0xBloctopus
- Targeting dev branch, so lower risk than main branch changes
- No functional code changes, only configuration metadata

---
**Link to Devin run**: https://app.devin.ai/sessions/c902258a44f043638d91d9f06ccef179  
**Requested by**: Til Jordan (@tiljrd)